### PR TITLE
celery 5 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,10 +47,7 @@ Quick start
 
     @app.on_after_configure.connect
     def setup_periodic_tasks(sender, **kwargs):
+        from drf_secure_token.tasks import DELETE_OLD_TOKENS
         sender.add_periodic_task(**DELETE_OLD_TOKENS)
-
-    or with scheduler config
-
-    'drf_secure_token.tasks.delete_old_tokens': DELETE_OLD_TOKENS,
 
 7. Run `python manage.py migrate` to create the drf_secure_token models.

--- a/README.rst
+++ b/README.rst
@@ -45,9 +45,12 @@ Quick start
 
 6.2 Celery 5, add periodic task manually::
 
-    @app.on_after_configure.connect
+    @app.on_after_finalize.connect
     def setup_periodic_tasks(sender, **kwargs):
         from drf_secure_token.tasks import DELETE_OLD_TOKENS
-        sender.add_periodic_task(**DELETE_OLD_TOKENS)
+
+        app.conf.beat_schedule.update({
+            'drf_secure_token.tasks.delete_old_tokens': DELETE_OLD_TOKENS,
+        })
 
 7. Run `python manage.py migrate` to create the drf_secure_token models.

--- a/README.rst
+++ b/README.rst
@@ -37,4 +37,16 @@ Quick start
 
     TOKEN_AGE = 60*10 # 10 min
 
-6. Run `python manage.py migrate` to create the drf_secure_token models.
+6. (Optional) To cleanup dead tokens celery can be used. Way to enable depends from celery version
+
+6.1 Celery 4, just enable it with settings::
+
+    REMOVE_TOKENS_THROUGH_CELERY = True
+
+6.2 Celery 5+, update scheduler to run task periodically::
+
+    @app.on_after_configure.connect
+    def setup_periodic_tasks(sender, **kwargs):
+        sender.add_periodic_task(drf_secure_token.tasks.DELETE_OLD_TOKENS)
+
+7. Run `python manage.py migrate` to create the drf_secure_token models.

--- a/README.rst
+++ b/README.rst
@@ -43,10 +43,14 @@ Quick start
 
     REMOVE_TOKENS_THROUGH_CELERY = True
 
-6.2 Celery 5+, update scheduler to run task periodically::
+6.2 Celery 5, add periodic task manually::
 
     @app.on_after_configure.connect
     def setup_periodic_tasks(sender, **kwargs):
-        sender.add_periodic_task(drf_secure_token.tasks.DELETE_OLD_TOKENS)
+        sender.add_periodic_task(**DELETE_OLD_TOKENS)
+
+    or with scheduler config
+
+    'drf_secure_token.tasks.delete_old_tokens': DELETE_OLD_TOKENS,
 
 7. Run `python manage.py migrate` to create the drf_secure_token models.

--- a/drf_secure_token/abstract_models.py
+++ b/drf_secure_token/abstract_models.py
@@ -4,7 +4,6 @@ import uuid
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
-from django.utils.six import python_2_unicode_compatible
 
 from rest_framework import exceptions
 
@@ -12,7 +11,6 @@ from drf_secure_token import checkers
 from drf_secure_token.settings import settings as token_settings
 
 
-@python_2_unicode_compatible
 class BaseToken(models.Model):
     @staticmethod
     def generate_key():

--- a/drf_secure_token/settings.py
+++ b/drf_secure_token/settings.py
@@ -2,7 +2,7 @@ from django.conf import settings as django_settings
 
 DEFAULT_SETTINGS = {
     'TOKEN_AGE': 0,
-    'UPDATE_TOKEN': not django_settings.DEBUG,
+    'UPDATE_TOKEN': not getattr(django_settings, 'DEBUG', False),
 
     'MUTABLE_PERIOD': 60 * 60 * 24 * 7,  # One week
 

--- a/drf_secure_token/tasks.py
+++ b/drf_secure_token/tasks.py
@@ -25,7 +25,8 @@ if CELERY_VERSION < (5, 0, 0):
         from celery.task import task
         delete_old_tokens = task(_delete_old_tokens)
 else:
-    delete_old_tokens = _delete_old_tokens
+    from celery import shared_task
+    delete_old_tokens = shared_task(_delete_old_tokens)
 
     DELETE_OLD_TOKENS = {
         'task': 'drf_secure_token.tasks.delete_old_tokens',

--- a/drf_secure_token/tasks.py
+++ b/drf_secure_token/tasks.py
@@ -1,17 +1,34 @@
 from django.utils import timezone
 
+from celery import VERSION as CELERY_VERSION
 from celery.schedules import crontab
-from celery.task import periodic_task
 
 from drf_secure_token.models import Token
 from drf_secure_token.settings import settings as token_settings
 
-if token_settings.REMOVE_TOKENS_THROUGH_CELERY:
-    @periodic_task(run_every=crontab(minute=0))
-    def delete_old_tokens():
-        now = timezone.now()
 
-        qs = Token.objects.all()
-        qs = qs.filter(dead_in__lt=now)
+def _delete_old_tokens():
+    now = timezone.now()
 
-        qs.delete()
+    qs = Token.objects.all()
+    qs = qs.filter(dead_in__lt=now)
+
+    qs.delete()
+
+
+# if setting enabled and default app exists (celery<5), use it. else just register task to be available for scheduler
+if CELERY_VERSION < (5, 0, 0):
+    if token_settings.REMOVE_TOKENS_THROUGH_CELERY:
+        from celery.task import periodic_task
+        delete_old_tokens = periodic_task(run_every=crontab(minute=0))(_delete_old_tokens)
+    else:
+        from celery.task import task
+        delete_old_tokens = task(_delete_old_tokens)
+else:
+    delete_old_tokens = _delete_old_tokens
+
+    DELETE_OLD_TOKENS = {
+        'task': 'drf_secure_token.tasks.delete_old_tokens',
+        'schedule': crontab(minute=0),
+        'args': ()
+    }

--- a/drf_secure_token/tasks.py
+++ b/drf_secure_token/tasks.py
@@ -7,7 +7,7 @@ from drf_secure_token.models import Token
 from drf_secure_token.settings import settings as token_settings
 
 
-def _delete_old_tokens():
+def delete_old_tokens():
     now = timezone.now()
 
     qs = Token.objects.all()
@@ -20,13 +20,13 @@ def _delete_old_tokens():
 if CELERY_VERSION < (5, 0, 0):
     if token_settings.REMOVE_TOKENS_THROUGH_CELERY:
         from celery.task import periodic_task
-        delete_old_tokens = periodic_task(run_every=crontab(minute=0))(_delete_old_tokens)
+        delete_old_tokens = periodic_task(run_every=crontab(minute=0))(delete_old_tokens)
     else:
         from celery.task import task
-        delete_old_tokens = task(_delete_old_tokens)
+        delete_old_tokens = task(delete_old_tokens)
 else:
     from celery import shared_task
-    delete_old_tokens = shared_task(_delete_old_tokens)
+    delete_old_tokens = shared_task(delete_old_tokens)
 
     DELETE_OLD_TOKENS = {
         'task': 'drf_secure_token.tasks.delete_old_tokens',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='drf-secure-token',
-    version='1.0.4',
+    version='1.1.0',
     packages=['drf_secure_token', 'drf_secure_token/migrations'],
     include_package_data=True,
     license='BSD License',
@@ -27,7 +27,6 @@ setup(
         'License :: OSI Approved :: BSD License',  # example license
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,16 @@
 [tox]
 envlist =
-    {py27,py36,py37}-django111
-    {py36,py37}-django{21,22}
+    {py36,py38}-django{21,22}-celery{4,5}
+    {py38}-django{30}-celery5
 [testenv]
 deps =
-    django111: django>=1.11,<2.0
     django21: django>=2.1,<2.2
     django22: django>=2.2,<2.3
-    django111: djangorestframework>=3.7,<3.11
+    django30: django>=3.0,<3.1
     django{21,22}: djangorestframework>=3.9,<3.11
-    celery
+    django{30}: djangorestframework
+    celery4: celery>=4,<5
+    celery5: celery>=5,<6
     mock
     coverage
 commands =


### PR DESCRIPTION
there is no default app like we had in 4- releases, so task should be planned manually for periodic execution.
updated readme with instructions for celery 5.
dropped python 2 and django 1.11 suport