### PR TITLE
Add support for django 4+

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,8 +2,7 @@
 line_length=120
 multi_line_output=3
 balanced_wrapping=true
-not_skip=__init__.py
-skip=migrations,deployer
+skip=migrations,deployer,.tox
 include_trailing_comma=true
 
 known_django=django

--- a/drf_secure_token/__init__.py
+++ b/drf_secure_token/__init__.py
@@ -1,1 +1,4 @@
-default_app_config = 'drf_secure_token.apps.DRFSecureTokenConfig'
+import django
+
+if django.VERSION < (3, 2):
+    default_app_config = 'drf_secure_token.apps.DRFSecureTokenConfig'

--- a/drf_secure_token/apps.py
+++ b/drf_secure_token/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class DRFSecureTokenConfig(AppConfig):

--- a/drf_secure_token/authentication.py
+++ b/drf_secure_token/authentication.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework import exceptions
 from rest_framework.authentication import TokenAuthentication

--- a/drf_secure_token/checkers.py
+++ b/drf_secure_token/checkers.py
@@ -1,5 +1,5 @@
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework.settings import perform_import
 

--- a/drf_secure_token/middleware.py
+++ b/drf_secure_token/middleware.py
@@ -1,16 +1,11 @@
 from django.utils import timezone
+from django.utils.deprecation import MiddlewareMixin
 
 from drf_secure_token.models import Token
 from drf_secure_token.settings import settings as token_settings
 
-try:
-    # Using MiddlewareMixin to add compatibility level between the new and old middleware styles.
-    from django.utils.deprecation import MiddlewareMixin as MiddlewareParent
-except ImportError:
-    MiddlewareParent = object
 
-
-class UpdateTokenMiddleware(MiddlewareParent):
+class UpdateTokenMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         token = getattr(request, 'auth', None)
         if not isinstance(token, Token):

--- a/drf_secure_token/models.py
+++ b/drf_secure_token/models.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from drf_secure_token.abstract_models import BaseToken, DyingTokenMixin
 

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,11 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='drf-secure-token',
-    version='1.1.0',
+    version='1.2.0',
     packages=['drf_secure_token', 'drf_secure_token/migrations'],
     include_package_data=True,
     license='BSD License',
-    description='Add secure token to djnago-rest-framework',
+    description='Add secure token to django-rest-framework',
     long_description=README,
     url='',
     author='Tima Akulich',

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -30,10 +30,12 @@ class MiddlewareTestCase(APITestCase):
             authenticators=[SecureTokenAuthentication()],
         )
         request._authenticate()
-        response = HttpResponse()
 
-        middleware = UpdateTokenMiddleware()
-        response = middleware.process_response(request._request, response)
+        def get_response(request):
+            return HttpResponse()
+
+        middleware = UpdateTokenMiddleware(get_response)
+        response = middleware(request._request)
 
         new_token = response.get('X-Token', None)
         self.assertIsNotNone(new_token)
@@ -58,10 +60,12 @@ class MiddlewareTestCase(APITestCase):
             authenticators=[SecureTokenAuthentication()],
         )
         request._authenticate()
-        response = HttpResponse()
 
-        middleware = UpdateTokenMiddleware()
-        response = middleware.process_response(request._request, response)
+        def get_response(request):
+            return HttpResponse()
+
+        middleware = UpdateTokenMiddleware(get_response)
+        response = middleware(request._request)
 
         new_token = response.get('X-Token', None)
         self.assertIsNone(new_token)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -19,3 +19,7 @@ DATABASES = {
         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
     },
 }
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
+USE_TZ = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,15 @@
 [tox]
 envlist =
-    {py36,py38}-django{21,22}-celery{4,5}
-    {py38}-django{30}-celery5
+    py38-django{32,42}
+    py310-django{32,42,50}
+    py{311,312}-django{42,50}
 [testenv]
 deps =
-    django21: django>=2.1,<2.2
-    django22: django>=2.2,<2.3
-    django30: django>=3.0,<3.1
-    django{21,22}: djangorestframework>=3.9,<3.11
-    django{30}: djangorestframework
-    celery4: celery>=4,<5
-    celery5: celery>=5,<6
+    django32: django>=3.2,<4.0
+    django42: django>=4.2,<5.0
+    django50: django>=5.0,<5.1
+    djangorestframework
+    celery>=5,<6
     mock
     coverage
 commands =


### PR DESCRIPTION
- Add support for django 4+, fix warnings
- Test with django 4+
- Test with python 3.10+
- Drop support for django<3.2
- Drop support for celery 4
- Drop support for python<3.8